### PR TITLE
Fix CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @heroku/buildpacks-admin
+* @heroku/languages


### PR DESCRIPTION
Resolves:

```
Unknown owner on line 1: make sure the team @heroku/buildpacks-admin exists, is publicly visible, and has write access to the repository

* @heroku/buildpacks-admin
```

(We don't need a separate team for this, the `@heroku/buildpacks-admin` team was created automatically by the tool that set up the repo for us.)