### PR TITLE
Pin SHA of third-party GitHub Actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -13,3 +13,8 @@ updates:
     directory: "/"
     schedule:
       interval: "monthly"
+    groups:
+      github-actions:
+        update-types:
+          - "minor"
+          - "patch"

--- a/.github/workflows/rundoc-ci.yml
+++ b/.github/workflows/rundoc-ci.yml
@@ -4,8 +4,9 @@ on:
     branches:
       - main
     paths:
-      - "docs/src/**"
+      - ".github/**"
       - ".rundoc-workspace/**"
+      - "docs/src/**"
 
 permissions:
   contents: read

--- a/.github/workflows/rundoc-ci.yml
+++ b/.github/workflows/rundoc-ci.yml
@@ -28,7 +28,7 @@ jobs:
         with:
           ruby-version: "3.3"
           bundler-cache: true # do run 'bundle install' and cache
-      - uses: buildpacks/github-actions/setup-pack@v5.8.8
+      - uses: buildpacks/github-actions/setup-pack@0f05ba41fb74d56ab4cb27485f538a8d65b4122e # v5.8.9
 
       # [CONFIG] add different languages set up here
       - run: |

--- a/.github/workflows/rundoc-pr.yml
+++ b/.github/workflows/rundoc-pr.yml
@@ -31,7 +31,7 @@ jobs:
         with:
           ruby-version: "3.3"
           bundler-cache: true # do run 'bundle install' and cache
-      - uses: buildpacks/github-actions/setup-pack@v5.8.8
+      - uses: buildpacks/github-actions/setup-pack@0f05ba41fb74d56ab4cb27485f538a8d65b4122e # v5.8.9
 
       - name: Run rundoc for all languages
         run: |
@@ -45,7 +45,7 @@ jobs:
         continue-on-error: true
       - name: Create Pull Request
         id: pr
-        uses: peter-evans/create-pull-request@v7
+        uses: peter-evans/create-pull-request@271a8d0340265f705b14b6d32b9829c1cb33d45e # v7.0.8
         with:
           token: ${{ steps.generate-token.outputs.token }}
           branch: rundoc-update


### PR DESCRIPTION
The full-version Git tags used by Actions are mutable (as seen in recent events in the wider GitHub Actions community), so pinning third-party Actions to a SHA is recommended:
https://docs.github.com/en/actions/security-for-github-actions/security-guides/security-hardening-for-github-actions#using-third-party-actions

The version tag has been added after the pin as a comment (as a readability aid) in a format that Dependabot will keep up to date: https://github.com/dependabot/dependabot-core/issues/4691

I've also:
- Enabled Dependabot grouping for GitHub Actions updates to reduce PR noise.
- Adjusted the CI workflow's `paths` config to also run CI when the `.github/` directory is modified, so workflow changes are tested on the PR prior to merge.

GUS-W-18051077.