### PR TITLE
Reduce scopes granted to `GITHUB_TOKEN` in GitHub Actions workflows

### DIFF
--- a/.github/workflows/rundoc-ci.yml
+++ b/.github/workflows/rundoc-ci.yml
@@ -6,6 +6,10 @@ on:
     paths:
       - "docs/src/**"
       - ".rundoc-workspace/**"
+
+permissions:
+  contents: read
+
 jobs:
   test-rundoc:
     runs-on: ubuntu-latest

--- a/.github/workflows/rundoc-pr.yml
+++ b/.github/workflows/rundoc-pr.yml
@@ -5,6 +5,10 @@ on:
     # This schedule triggers the workflow at 00:00 every Monday
     - cron: "0 0 * * 1"
   workflow_dispatch:
+
+# Disable all GITHUB_TOKEN permissions, since the GitHub App token is used instead.
+permissions: {}
+
 jobs:
   run-rundoc:
     runs-on: pub-hk-ubuntu-24.04-ip


### PR DESCRIPTION
As part of security-hardening our GHA workflows, this reduces the permissions granted to the automatically set `GITHUB_TOKEN` env var in GitHub Actions workflows to no more than what is required by that workflow.

See:
https://docs.github.com/en/actions/security-for-github-actions/security-guides/security-hardening-for-github-actions https://docs.github.com/en/actions/security-for-github-actions/security-guides/automatic-token-authentication

GUS-W-18053749.