### PR TITLE
Adjust cron for update PR

### DIFF
--- a/.github/workflows/rundoc-pr.yml
+++ b/.github/workflows/rundoc-pr.yml
@@ -3,7 +3,7 @@ run-name: execute rundoc on tutorials
 on:
   schedule:
     # This schedule triggers the workflow at 00:00 every Monday
-    - cron: "0 0 * * 1"
+    - cron: "0 8 * * 1"
   workflow_dispatch:
 
 # Disable all GITHUB_TOKEN permissions, since the GitHub App token is used instead.


### PR DESCRIPTION
Moves the scheduled job from 00:00 to 08:00 every Monday, so that:
(a) the generated guides don't have middle-of-the-night timestamps in the logs,
(b) the guides are as fresh as possible when the PRs are reviewed/merged business hours Monday.