### PR TITLE
Alert maintainer when docs fail to build

### DIFF
--- a/.github/workflows/failure_free_docs.yml
+++ b/.github/workflows/failure_free_docs.yml
@@ -1,0 +1,29 @@
+name: failure_free_docs
+on:
+  pull_request:
+    paths:
+      - "docs/fail/**"
+
+permissions:
+  contents: read
+
+jobs:
+  checks_docs_for_failures:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.head_ref }}
+      - name: Check PR for failures
+        run: |
+          FAILING=$(find ./docs/fail -type f)
+          if [ -z "$FAILING" ]; then
+            echo "No failing docs found"
+          else
+            echo "ERROR:"
+            echo "Failing docs found. Delete the files and retry generation."
+            echo "If the failure persists, notify the language owner"
+            echo
+            echo "$FAILING"
+            exit 1
+          fi

--- a/.github/workflows/failure_free_docs.yml
+++ b/.github/workflows/failure_free_docs.yml
@@ -1,8 +1,6 @@
 name: failure_free_docs
 on:
   pull_request:
-    paths:
-      - "docs/fail/**"
 
 permissions:
   contents: read

--- a/.github/workflows/failure_free_docs.yml
+++ b/.github/workflows/failure_free_docs.yml
@@ -8,22 +8,17 @@ permissions:
   contents: read
 
 jobs:
-  checks_docs_for_failures:
+  checks-docs-for-failures:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-        with:
-          ref: ${{ github.head_ref }}
       - name: Check PR for failures
         run: |
-          FAILING=$(find ./docs/fail -type f)
-          if [ -z "$FAILING" ]; then
+          if [[ -e ./docs/fail ]]; then
             echo "No failing docs found"
           else
-            echo "ERROR:"
-            echo "Failing docs found. Delete the files and retry generation."
-            echo "If the failure persists, notify the language owner"
-            echo
-            echo "$FAILING"
+            echo "ERROR: Failing docs found in the ./docs/fail/ directory!"
+            echo "Try retriggering the rundoc job to see if the failures are intermittent."
+            echo "If the failure persists, notify the language owner."
             exit 1
           fi

--- a/.github/workflows/failure_free_docs.yml
+++ b/.github/workflows/failure_free_docs.yml
@@ -13,10 +13,10 @@ jobs:
       - name: Check PR for failures
         run: |
           if [[ -e ./docs/fail ]]; then
-            echo "No failing docs found"
-          else
             echo "ERROR: Failing docs found in the ./docs/fail/ directory!"
             echo "Try retriggering the rundoc job to see if the failures are intermittent."
             echo "If the failure persists, notify the language owner."
             exit 1
+          else
+            echo "No failing docs found"
           fi


### PR DESCRIPTION
In #104 the docs had a failure but since there's so many pages changed it went un-noticed. This adds a check that will fail the PR if anything in the fail dir is committed for more visiblity.