### PR TITLE
Update builder image to `heroku/builder:26`

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ $ git clone https://github.com/heroku/nodejs-getting-started.git
 In your application directory, run the `pack build` command. No additional steps are needed! The required buildpacks for your app will be detected automatically:
 
 ```
-$ pack build my-app-image --builder heroku/builder:24 --path nodejs-getting-started
+$ pack build my-app-image --builder heroku/builder:26 --path nodejs-getting-started
 ```
 
 Once the image is built, you can run it with the tools you're already comfortable with, like the `docker` CLI, for a demonstration of how [read out getting started tutorials](docs/README.md).

--- a/docs/src/shared/configure_builder.md
+++ b/docs/src/shared/configure_builder.md
@@ -3,9 +3,9 @@
 Once `pack` is installed, the only configuration you'll need for this tutorial is to set a default builder:
 
 ```
-:::-- $ docker pull heroku/builder:24
-:::-- $ docker pull heroku/heroku:24
-:::>> $ pack config default-builder heroku/builder:24
+:::-- $ docker pull heroku/builder:26
+:::-- $ docker pull heroku/heroku:26
+:::>> $ pack config default-builder heroku/builder:26
 ```
 
 You can view your default builder at any time:
@@ -14,4 +14,4 @@ You can view your default builder at any time:
 :::>> $ pack config default-builder
 ```
 
-> Note: The `heroku/builder:24` supports both amd64 (also known as x86) and arm64 (such as aarch64 used with newer Mac machines) architectures. If needed, you can configure the architecture for `docker` and `pack` CLIs using the `--platform` argument if needed. For example `--platform linux/amd64`.
+> Note: The `heroku/builder:26` builder supports both amd64 (also known as x86) and arm64 (such as aarch64 used with newer Mac machines) architectures. If needed, you can configure the architecture for `docker` and `pack` CLIs using the `--platform` argument if needed. For example `--platform linux/amd64`.

--- a/docs/src/shared/what_is_a_builder.md
+++ b/docs/src/shared/what_is_a_builder.md
@@ -9,7 +9,7 @@ In short, a builder is a delivery mechanism for buildpacks. A builder contains r
 You can view the contents of a builder via the command `pack builder inspect`. For example:
 
 ```
-:::>> $ pack builder inspect heroku/builder:24 | awk '/^Buildpacks:/ {flag=1} /^Detection Order:/ {exit} flag'
+:::>> $ pack builder inspect heroku/builder:26 | awk '/^Buildpacks:/ {flag=1} /^Detection Order:/ {exit} flag'
 ```
 
 > [!NOTE]


### PR DESCRIPTION
Bumps references in the top-level README and the shared rundoc sources from `heroku/builder:24` (and `heroku/heroku:24`) to the `:26` tags. The language-specific tutorial READMEs are auto-generated from the rundoc sources and will be regenerated separately.

GUS-W-22580946.