### PR TITLE
Update to rundoc 7

### DIFF
--- a/.rundoc-workspace/Gemfile
+++ b/.rundoc-workspace/Gemfile
@@ -3,4 +3,4 @@
 source 'https://rubygems.org'
 ruby '~> 3.3'
 
-gem 'rundoc', '~> 6.0'
+gem 'rundoc', '~> 7.0'

--- a/.rundoc-workspace/Gemfile.lock
+++ b/.rundoc-workspace/Gemfile.lock
@@ -4,8 +4,8 @@ GEM
     addressable (2.9.0)
       public_suffix (>= 2.0.2, < 8.0)
     aws-eventstream (1.4.0)
-    aws-partitions (1.1255.0)
-    aws-sdk-core (3.250.0)
+    aws-partitions (1.1263.0)
+    aws-sdk-core (3.252.0)
       aws-eventstream (~> 1, >= 1.3.0)
       aws-partitions (~> 1, >= 1.992.0)
       aws-sigv4 (~> 1.9)
@@ -13,10 +13,10 @@ GEM
       bigdecimal
       jmespath (~> 1, >= 1.6.1)
       logger
-    aws-sdk-kms (1.128.0)
+    aws-sdk-kms (1.129.0)
       aws-sdk-core (~> 3, >= 3.248.0)
       aws-sigv4 (~> 1.5)
-    aws-sdk-s3 (1.224.0)
+    aws-sdk-s3 (1.226.0)
       aws-sdk-core (~> 3, >= 3.248.0)
       aws-sdk-kms (~> 1)
       aws-sigv4 (~> 1.5)
@@ -33,7 +33,7 @@ GEM
       rack-test (>= 0.6.3)
       regexp_parser (>= 1.5, < 3.0)
       xpath (~> 3.2)
-    cgi (0.5.1)
+    cgi (0.5.2)
     dotenv (3.2.0)
     jmespath (1.6.2)
     logger (1.7.0)
@@ -61,8 +61,8 @@ GEM
       rack (>= 1.3)
     regexp_parser (2.12.0)
     rexml (3.4.4)
-    rubyzip (3.3.1)
-    rundoc (6.0.0)
+    rubyzip (3.4.1)
+    rundoc (7.0.0)
       aws-sdk-s3 (~> 1)
       base64 (~> 0)
       capybara (~> 3)
@@ -71,7 +71,7 @@ GEM
       parslet (~> 2)
       selenium-webdriver (~> 4)
       thor
-    selenium-webdriver (4.44.0)
+    selenium-webdriver (4.45.0)
       base64 (~> 0.2)
       logger (~> 1.4)
       rexml (~> 3.2, >= 3.2.5)
@@ -91,7 +91,7 @@ PLATFORMS
   x86_64-linux
 
 DEPENDENCIES
-  rundoc (~> 6.0)
+  rundoc (~> 7.0)
 
 RUBY VERSION
    ruby 3.3.2p78

--- a/docs/src/shared/download.md
+++ b/docs/src/shared/download.md
@@ -22,5 +22,5 @@ Verify you're in the correct directory:
 This tutorial was built using the following commit SHA:
 
 ```
-:::>> $ git log --oneline | head -n1
+:::>> $ git log --oneline -n1
 ```

--- a/docs/src/shared/what_is_a_builder.md
+++ b/docs/src/shared/what_is_a_builder.md
@@ -9,7 +9,7 @@ In short, a builder is a delivery mechanism for buildpacks. A builder contains r
 You can view the contents of a builder via the command `pack builder inspect`. For example:
 
 ```
-:::>> $ pack builder inspect heroku/builder:26 | awk '/^Buildpacks:/ {flag=1} /^Detection Order:/ {exit} flag'
+:::>> $ pack builder inspect heroku/builder:26 | awk '/^Buildpacks:/ {flag=1} /^Detection Order:/ {flag=0} flag'
 ```
 
 > [!NOTE]


### PR DESCRIPTION
rundoc 7.0 runs shell commands under `bash -eo pipefail` instead of `/bin/sh`, so a pipeline now fails if any non-final stage exits non-zero. Two commands in the shared tutorial sources had a stage that closes the pipe early, killing the upstream producer with SIGPIPE (141) and failing all nine language suites:

- `pack builder inspect ... | awk '... {exit} flag'` — awk's `exit` closes the pipe, so `pack` dies with SIGPIPE. Use `{flag=0}` so awk reads to EOF; output is identical.
- `git log --oneline | head -n1` — `head` closes the pipe. Use `git log --oneline -n1`, which needs no pipe.

Supersedes #235.

GUS-W-23272880.
