### PR TITLE
Fix duplicated buildpack list in builder inspect output

### DIFF
--- a/docs/src/shared/what_is_a_builder.md
+++ b/docs/src/shared/what_is_a_builder.md
@@ -9,7 +9,7 @@ In short, a builder is a delivery mechanism for buildpacks. A builder contains r
 You can view the contents of a builder via the command `pack builder inspect`. For example:
 
 ```
-:::>> $ pack builder inspect heroku/builder:26 | awk '/^Buildpacks:/ {flag=1} /^Detection Order:/ {flag=0} flag'
+:::>> $ pack builder inspect heroku/builder:26 | awk '/^Buildpacks:/ && !seen {flag=1} /^Detection Order:/ {flag=0; seen=1} flag'
 ```
 
 > [!NOTE]


### PR DESCRIPTION
PR #237 changed the awk filter from `{exit}` to `{flag=0}` to avoid a SIGPIPE under rundoc 7's `bash -eo pipefail`. But `pack builder inspect` prints two `Buildpacks:` sections (REMOTE and LOCAL), and `{flag=0}` lets the second section re-enable `flag`, so the list is printed twice (see PR #238's regenerated tutorials).

The old `{exit}` had masked this by killing awk after the first section. Latch `flag` off after the first `Detection Order:` so the second `Buildpacks:` can't re-enable it. Output matches the pre-#237 single-section result and awk still reads to EOF, so no SIGPIPE.

GUS-W-23272880.